### PR TITLE
cleanup: fix DOCTYPE, charset/viewport, replace dead CDN URLs

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,13 +1,15 @@
-<!DOCTYPE html5>
-<html>
+<!DOCTYPE html>
+<html lang="en">
 	<head>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, initial-scale=1">
 		<title>RoboBattles</title>
-		<link rel="stylesheet" href="//netdna.bootstrapcdn.com/bootstrap/3.1.1/css/bootstrap.min.css">
-		<link rel="stylesheet" href="//netdna.bootstrapcdn.com/bootstrap/3.1.1/css/bootstrap-theme.min.css">
+		<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@3.1.1/dist/css/bootstrap.min.css">
+		<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@3.1.1/dist/css/bootstrap-theme.min.css">
 		<link rel="stylesheet" href="css/style.css">
 
-		<script src="//code.jquery.com/jquery-2.1.1.min.js"></script>
-		<script src="//netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js"></script>
+		<script src="https://cdn.jsdelivr.net/npm/jquery@2.1.1/dist/jquery.min.js"></script>
+		<script src="https://cdn.jsdelivr.net/npm/bootstrap@3.1.1/dist/js/bootstrap.min.js"></script>
 
 	</head>
 	<body>


### PR DESCRIPTION
## Summary

Light-touch cleanup of `index.html` — game logic and layout are untouched.

- `<!DOCTYPE html5>` → `<!DOCTYPE html>` (the former is invalid; `html5` is not a valid doctype)
- Added `<meta charset="utf-8">` and `<meta name="viewport" ...>`
- Added `lang="en"` on `<html>`
- Replaced dead CDN URLs (`netdna.bootstrapcdn.com` was decommissioned) with jsDelivr equivalents, pinned to the same versions (Bootstrap 3.1.1, jQuery 2.1.1) so nothing breaks
- Replaced `//`-relative protocol URLs with explicit `https://`

## CDN replacements

| Before | After |
|---|---|
| `//netdna.bootstrapcdn.com/bootstrap/3.1.1/css/bootstrap.min.css` | `https://cdn.jsdelivr.net/npm/bootstrap@3.1.1/dist/css/bootstrap.min.css` |
| `//netdna.bootstrapcdn.com/bootstrap/3.1.1/css/bootstrap-theme.min.css` | `https://cdn.jsdelivr.net/npm/bootstrap@3.1.1/dist/css/bootstrap-theme.min.css` |
| `//code.jquery.com/jquery-2.1.1.min.js` | `https://cdn.jsdelivr.net/npm/jquery@2.1.1/dist/jquery.min.js` |
| `//netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js` | `https://cdn.jsdelivr.net/npm/bootstrap@3.1.1/dist/js/bootstrap.min.js` |

## gh-pages note

The live site at `mosni.github.io/robobattles` is served from the `gh-pages` branch. Once this merges to `master`, `gh-pages` needs to be updated (fast-forward merge or cherry-pick) to pick up the CDN fix. The entry in `mosni.dev`'s projects.json points to the gh-pages URL.

---
_Generated by [Claude Code](https://claude.ai/code/session_019E9m48trzpErno3iYRcZ7F)_